### PR TITLE
alphabetize podcasts

### DIFF
--- a/app/pwa/views.py
+++ b/app/pwa/views.py
@@ -4,7 +4,7 @@ import time
 from app import app
 from app.pwa.pod import Podcast
 
-VERSION = "0.3.66"
+VERSION = "0.3.67"
 
 @app.route('/pwa', methods=['GET'])
 def pwa():

--- a/app/static/pwa/pages/podcasts.html
+++ b/app/static/pwa/pages/podcasts.html
@@ -31,11 +31,6 @@
         <div class="podcastTitle">Checklist</div>
     </div>
 
-    <div id="cirrus" class="podcastIndividual" onclick="loadPodcast(this.id)">
-        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/cirrus/image.jpg">
-        <div class="podcastTitle">Hourly Weather Forecast</div>
-    </div>
-
     <div id="community" class="podcastIndividual" onclick="loadPodcast(this.id)">
         <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/community/image.jpg">
         <div class="podcastTitle">Community News</div>
@@ -86,17 +81,17 @@
         <div class="podcastTitle">An Hour of Short Stories</div>
     </div>
 
+    <div id="cirrus" class="podcastIndividual" onclick="loadPodcast(this.id)">
+        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/cirrus/image.jpg">
+        <div class="podcastTitle">Hourly Weather Forecast</div>
+    </div>
+
     <div id="independent" class="podcastIndividual" onclick="loadPodcast(this.id)">
         <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/independent/image.jpg">
         <div class="podcastTitle">Independent Living</div>
     </div>
 
-    <div id="ledger" class="podcastIndividual" onclick="loadPodcast(this.id)">
-        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/ledger/image.jpg">
-        <div class="podcastTitle">The Nashville Ledger</div>
-    </div>
-
-    <div id="lgbt" class="podcastIndividual" onclick="loadPodcast(this.id)">
+       <div id="lgbt" class="podcastIndividual" onclick="loadPodcast(this.id)">
         <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/lgbt/image.jpg">
         <div class="podcastTitle">LGBTQ News & Culture</div>
     </div>
@@ -111,19 +106,24 @@
         <div class="podcastTitle">Money Talk</div>
     </div>
 
+    <div id="ledger" class="podcastIndividual" onclick="loadPodcast(this.id)">
+        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/ledger/image.jpg">
+        <div class="podcastTitle">The Nashville Ledger</div>
+    </div>
+
+    <div id="scene" class="podcastIndividual" onclick="loadPodcast(this.id)">
+        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/scene/image.jpg">
+        <div class="podcastTitle">The Nashville Scene</div>
+    </div>
+
     <div id="nationalgeo" class="podcastIndividual" onclick="loadPodcast(this.id)">
         <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/nationalgeo/image.jpg">
         <div class="podcastTitle">National Geographic</div>
     </div>
 
-    <div id="newsweek" class="podcastIndividual" onclick="loadPodcast(this.id)">
-        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/newsweek/image.jpg">
-        <div class="podcastTitle">Newsweek</div>
-    </div>
-
-    <div id="newyorker" class="podcastIndividual" onclick="loadPodcast(this.id)">
-        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/newyorker/image.jpg">
-        <div class="podcastTitle">The New Yorker</div>
+    <div id="science" class="podcastIndividual" onclick="loadPodcast(this.id)">
+        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/science/image.jpg">
+        <div class="podcastTitle">New Scientist</div>
     </div>
 
     <div id="nyt" class="podcastIndividual" onclick="loadPodcast(this.id)">
@@ -131,9 +131,14 @@
         <div class="podcastTitle">The New York Times</div>
     </div>
 
-    <div id="opinion" class="podcastIndividual" onclick="loadPodcast(this.id)">
-        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/opinion/image.jpg">
-        <div class="podcastTitle">Tennessean Opinions</div>
+    <div id="newyorker" class="podcastIndividual" onclick="loadPodcast(this.id)">
+        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/newyorker/image.jpg">
+        <div class="podcastTitle">The New Yorker</div>
+    </div>
+
+    <div id="newsweek" class="podcastIndividual" onclick="loadPodcast(this.id)">
+        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/newsweek/image.jpg">
+        <div class="podcastTitle">Newsweek</div>
     </div>
 
     <div id="people" class="podcastIndividual" onclick="loadPodcast(this.id)">
@@ -146,14 +151,14 @@
         <div class="podcastTitle">Pet Potpourri</div>
     </div>
 
-    <div id="pns" class="podcastIndividual" onclick="loadPodcast(this.id)">
-        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/pns/image.jpg">
-        <div class="podcastTitle">PNS Daily Newscast</div>
-    </div>
-
     <div id="pnstalks" class="podcastIndividual" onclick="loadPodcast(this.id)">
         <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/pnstalks/image.jpg">
         <div class="podcastTitle">PNS 2025 Talks</div>
+    </div>
+
+    <div id="pns" class="podcastIndividual" onclick="loadPodcast(this.id)">
+        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/pns/image.jpg">
+        <div class="podcastTitle">PNS Daily Newscast</div>
     </div>
 
     <div id="pnsyonder" class="podcastIndividual" onclick="loadPodcast(this.id)">
@@ -181,16 +186,6 @@
         <div class="podcastTitle">Rolling Stone</div>
     </div>
 
-    <div id="scene" class="podcastIndividual" onclick="loadPodcast(this.id)">
-        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/scene/image.jpg">
-        <div class="podcastTitle">The Nashville Scene</div>
-    </div>
-
-    <div id="science" class="podcastIndividual" onclick="loadPodcast(this.id)">
-        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/science/image.jpg">
-        <div class="podcastTitle">New Scientist</div>
-    </div>
-
     <div id="smithsonian" class="podcastIndividual" onclick="loadPodcast(this.id)">
         <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/smithsonian/image.jpg">
         <div class="podcastTitle">The Smithsonian</div>
@@ -204,6 +199,11 @@
     <div id="tennessean" class="podcastIndividual" onclick="loadPodcast(this.id)">
         <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/tennessean/image.jpg">
         <div class="podcastTitle">The Tennessean</div>
+    </div>
+
+    <div id="opinion" class="podcastIndividual" onclick="loadPodcast(this.id)">
+        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/opinion/image.jpg">
+        <div class="podcastTitle">Tennessean Opinions</div>
     </div>
 
     <div id="time" class="podcastIndividual" onclick="loadPodcast(this.id)">
@@ -221,6 +221,11 @@
         <div class="podcastTitle">Vanity Fair</div>
     </div>
 
+    <div id="wsj" class="podcastIndividual" onclick="loadPodcast(this.id)">
+        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/wsj/image.jpg">
+        <div class="podcastTitle">The Wall Street Journal</div>
+    </div>
+
     <div id="wired" class="podcastIndividual" onclick="loadPodcast(this.id)">
         <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/wired/image.jpg">
         <div class="podcastTitle">Wired</div>
@@ -229,11 +234,6 @@
     <div id="woman" class="podcastIndividual" onclick="loadPodcast(this.id)">
         <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/woman/image.jpg">
         <div class="podcastTitle">Woman's World</div>
-    </div>
-
-    <div id="wsj" class="podcastIndividual" onclick="loadPodcast(this.id)">
-        <img class="podcastImages" src="https://assets.library.nashville.org/talkinglibrary/shows/wsj/image.jpg">
-        <div class="podcastTitle">The Wall Street Journal</div>
     </div>
 
 </div>


### PR DESCRIPTION
I think this should be alphabetized correctly now. I checked it against our NTL website and the only discrepancy is they have "An Hour of Short Stories" listed with by the letter A. I've checked a couple resources online and while it says sorting by articles is ok, I've always thought it's easier to search when keeping those out (a, an, the, etc.). Anyways, thanks again and let me know if anything is wrong!
 