### PR TITLE
missed another Icecast URL

### DIFF
--- a/app/status/ping.py
+++ b/app/status/ping.py
@@ -133,7 +133,7 @@ class Icecast:
         return sources
 
     def user_agent_ip(self, mount) -> list:
-        icecast_URL = f"http://npl.streamguys1.com:/admin/listclients?mount=/{mount}"
+        icecast_URL = f"https://npl.streamguys1.com/admin/listclients?mount=/{mount}"
         header = {'User-Agent': 'Booth Finder'}
         tree = requests.get(icecast_URL, auth=(self.ev.icecast_user, self.ev.icecast_pass), headers=header)
         tree = tree.text


### PR DESCRIPTION
I searched the repo this time, this is the last one! I searched for other outside API calls, as well, and didn't find any still using HTTP instead of HTTPS.